### PR TITLE
[codex] fix zhuyin cow lifetime

### DIFF
--- a/dodo-zh/src/zhuyin.rs
+++ b/dodo-zh/src/zhuyin.rs
@@ -62,7 +62,7 @@ impl Zhuyin {
     ///
     /// * `&self` - Self
     /// * `pinyin` - S
-    pub fn get_zhuyin_from_pinyin<S>(&self, pinyin: S) -> Cow<str>
+    pub fn get_zhuyin_from_pinyin<S>(&self, pinyin: S) -> Cow<'_, str>
     where
         S: AsRef<str>,
     {


### PR DESCRIPTION
## Summary

Fix the `dodo-zh` Zhuyin API return type by making the elided `Cow` lifetime explicit.

## Impact

This keeps the Rust 2024 crate check clean for the `dodo-zh` package without changing behavior.

## Validation

- `cargo check -p dodo-zh`